### PR TITLE
Remove conflicting keybindings

### DIFF
--- a/README.org
+++ b/README.org
@@ -316,6 +316,7 @@ Present users with a friendly and fun welcome screen on initial startup.
   (defun starmacs/welcome ()
     (interactive)
      "Show minimal *welcome* buffer"
+     (delete-other-windows)
      (with-current-buffer (get-buffer-create "*Welcome*")
        (setq truncate-lines t)
        (no-linum)
@@ -1211,5 +1212,6 @@ If you're starting up for the first time, a bunch of warnings and windows and su
 Let's get rid of those and show you the dashboard
 
 #+begin_src emacs-lisp
-  (starmacs/welcome)
+  (when starmacs/initial-install
+    (starmacs/welcome))
 #+end_src

--- a/README.org
+++ b/README.org
@@ -74,16 +74,6 @@ When text is highlighted, typing should delete the highlighted text and insert w
   (delete-selection-mode 1)
 #+end_src
 
-** Usage Guides
-=discover.el= mostly just helps with =dired= mode, but it's worth including for new users.
-
-#+begin_src emacs-lisp
-  (use-package discover
-    :ensure t
-    :config
-    (global-discover-mode 1))
-#+end_src
-
 ** Mouse in Terminal
 If Emacs is run in the terminal, the mouse should continue to work.
 
@@ -351,6 +341,16 @@ as well as keeping track of the current scope
 
 ** Fonts
 *** Default Fonts
+Starmacs comes with a set of default fonts, which are are listed and attributed below:
+
+- [[https://github.com/be5invis/Iosevka][Iosevka]]: A monospaced font with a distinct look, and a wide range of weights.
+- [[https://github.com/github/mona-sans][Mona Sans]]: A strong and versitile typeface inspired by industrial-era grotesques made by GitHub.
+- [[https://github.com/github/hubot-sans][Hubot-Sans]]: The typeface is designed with more geometric accents to lend a technical and idiosyncratic feel—perfect for headers and pull-quotes. Also made by GitHub.
+
+All three licenses are distributed under the SIL Open Font License, and are available for free.
+
+If you have fonts that you prefer, the easiest way to override these defaults is to duplicate this config (with your preferred fonts) inside the =/usr= directory.
+
 **** Install Defaults
 Ensure that the fonts packaged with Starmacs are installed correctly.
 Currently, this assumes that the user is using macOS.
@@ -367,21 +367,19 @@ This will be later expanded to support all *nix, and perhaps Windows.
           (call-process "/bin/bash" nil nil nil "-c" "cp ~/.emacs.d/fonts/*.ttf ~/Library/Fonts")
           (message "Installed Default Fonts"))))
 #+end_src
+
 **** Set Defaults
 #+begin_src emacs-lisp
-      (defvar starmacs/fixed-pitch-height 130)
+      (defvar starmacs/fixed-pitch-height 150)
       (defvar starmacs/variable-pitch-height 130)
       (setq-default line-spacing 0.2)
 
-      (defvar starmacs/fixed-pitch-font (if (member "Berkeley Mono" (font-family-list))
-                                         "Berkeley Mono"
-                                       "SF Mono"))
-
-      (if (not (and (member "Hubot-Sans" (font-family-list)) (member "Mona Sans" (font-family-list))))
+      (if (not (and (member "Iosevka" (font-family-list))(member "Hubot-Sans" (font-family-list)) (member "Mona Sans" (font-family-list))))
           (install-default-fonts))
 
       (defvar starmacs/variable-pitch-font "Mona Sans")
       (defvar starmacs/title-font "Hubot-Sans")
+      (defvar starmacs/fixed-pitch-font "Iosevka")
 
 
       (set-face-attribute 'default nil :font starmacs/fixed-pitch-font :height starmacs/fixed-pitch-height)
@@ -1007,6 +1005,8 @@ logged in on this machine. In order to enable copilot, bind the variable
     :config
     (define-key copilot-completion-map (kbd "C-f") 'copilot-accept-completion) ; using forward motion to accept completion like Warp
     (define-key copilot-completion-map (kbd "<right>") 'copilot-accept-completion)
+    (unless (copilot-installed-version)
+  	  (copilot-install-server))
     :ensure t)
 #+end_src
 
@@ -1092,7 +1092,7 @@ Emacs 29+ comes with =eglot=, an LSP system, built-in.
     (zig-mode . eglot-ensure)
     :config (setq lsp-prefer-flymake nil))
 #+end_src
- 
+
 *** Eldoc
 #+begin_src emacs-lisp
   (use-package eldoc-box
@@ -1148,23 +1148,29 @@ client has been bundled in. To use it, simply put your OpenAI API key in the fil
 =~/.emacs.d/chatgpt-api-key.txt=, and it will be automatically read when
 a new shell is opened with =M-x chatgpt-shell=
 #+begin_src emacs-lisp
+  (setq starmacs/chatgpt-api-key (expand-file-name "chatgpt-api-key.txt"))
+
   (use-package chatgpt-shell
     :ensure t
     :straight (:host github :repo "xenodium/chatgpt-shell" :files ("dist" "*.el"))
     :config
+    (unless
+  	  (file-exists-p starmacs/chatgpt-api-key)
+  	(make-empty-file starmacs/chatgpt-api-key))
+
     (setq chatgpt-shell-openai-key (replace-regexp-in-string "\n\\'" "" (with-temp-buffer
-                                     (insert-file-contents "~/.emacs.d/chatgpt-api-key.txt")
-                                     (buffer-string)))))
+  																		(insert-file-contents (expand-file-name "chatgpt-api-key.txt"))
+  																		(buffer-string)))))
 #+end_src
 
 * User Code
 In order to allow the user to use a better editing environment when adding your /own/
 code to Starmacs, the =usr= directory is added to the load-path. This means that
-any file added in =~.emacs.d/usr/= will we automatically evaluated when
+any file added in =./usr/= will we automatically evaluated when
 Emacs is launched.. This way, Emacs Lisp code can be edited in a dedicated
 buffer, rather than in a source block in an org document
 #+begin_src emacs-lisp
-  (let ((default-directory  "~/.emacs.d/usr/"))
+  (let ((default-directory  user-emacs-directory))
     (normal-top-level-add-subdirs-to-load-path))
 
   (defun starmacs/load-user-code (dir)
@@ -1178,6 +1184,6 @@ buffer, rather than in a source block in an org document
           (load library nil t)
           (push library libraries-loaded))))))
 
-  (starmacs/load-user-code "~/.emacs.d/usr/")
+  (when (file-exists-p (expand-file-name "./usr"))
+    (starmacs/load-user-code (expand-file-name "./usr")))
 #+end_src
-

--- a/README.org
+++ b/README.org
@@ -1213,5 +1213,6 @@ Let's get rid of those and show you the dashboard
 
 #+begin_src emacs-lisp
   (when starmacs/initial-install
-    (starmacs/welcome))
+    (starmacs/welcome)
+    (move-beginning-of-line nil))
 #+end_src

--- a/README.org
+++ b/README.org
@@ -45,6 +45,27 @@ Starmacs is not necessarily for everyone; you may prefer one of the following:
 [[https://github.com/hlissner/doom-emacs][Doom Emacs]]
 [[https://github.com/bbatsov/prelude][Prelude]]
 
+* Installation
+** Dependencies
+The =magit= package installed by Starmacs expects you to have =sqlite= installed on your system.
+Installation will vary based on your system, but it is generally available as a package for most package managers.
+
+** Cloning the Repository
+Simply clone this repository into your =~/.emacs.d= directory.
+The next time you start emacs, it will automatically install all of the packages and set up the configuration.
+As is mentioned later in this document, any custom configuration should be added to the =~/usr= directory.
+This prevents the need to merge changes when the repository is updated.
+Feel free to update this file directly if you wish, but be aware that pulling updates will become a headache.
+
+Alternately, after cloning this repository, you can simply delete the =.git= directory and start a new repository.
+That way, Starmacs can simply serve as a starting point for your own configuration, rather than a living distribution.
+
+Either way is fine, and the choice is yours!
+
+*** Note: =sqlite-api=
+When you first start up Starmacs, there will be a prompt to build the =sqlite-api=.
+After entering 'yes', the installation will proceed as normal.
+
 * Quality of Life Improvements
 ** Keep Buffers Up to Date with Files
 When files on disk change, open buffers should be automatically updated to reflect those changes.
@@ -325,7 +346,6 @@ Present users with a friendly and fun welcome screen on initial startup.
     (add-hook 'emacs-startup-hook (lambda ()
                                    (when (display-graphic-p)
                                      (starmacs/welcome)))))
-
 #+end_src
 
 *** Rainbow Delimiters
@@ -359,12 +379,10 @@ This will be later expanded to support all *nix, and perhaps Windows.
 
   #+begin_src emacs-lisp
     (defun install-default-fonts ()
-      (when (and
-             (window-system)
-             (string-equal system-type "darwin"))
+      (when (window-system)
         (progn
           (message "Installing Default Fonts")
-          (call-process "/bin/bash" nil nil nil "-c" "cp ~/.emacs.d/fonts/*.ttf ~/Library/Fonts")
+          (shell-command (expand-file-name "install-fonts.sh"))
           (message "Installed Default Fonts"))))
 #+end_src
 
@@ -1186,4 +1204,12 @@ buffer, rather than in a source block in an org document
 
   (when (file-exists-p (expand-file-name "./usr"))
     (starmacs/load-user-code (expand-file-name "./usr")))
+#+end_src
+
+* Initial Startup
+If you're starting up for the first time, a bunch of warnings and windows and such are created.
+Let's get rid of those and show you the dashboard
+
+#+begin_src emacs-lisp
+  (starmacs/welcome)
 #+end_src

--- a/init.el
+++ b/init.el
@@ -7,6 +7,11 @@
 ;; packages, and are not meant to be directly edited.
 ;; It then loads the code in README.org
 
+;;; Initial Install
+;; This variable is used to determine if the user is installing Starmacs for the first time, which we use to dismiss the initial warnings
+;; and force the display of the dashboard.
+(setq starmacs/initial-install (not (file-exists-p (expand-file-name "straight/repos/straight.el" user-emacs-directory))))
+
 ;;; Code:
 ;; Added by Package.el.  This must come before configurations of
 ;; installed packages.  Don't delete this line.  If you don't want it,
@@ -66,90 +71,6 @@
  ;; If you edit it by hand, you could mess it up, so be careful.
  ;; Your init file should contain only one such instance.
  ;; If there is more than one, they won't work right.
- '(connection-local-criteria-alist
-   '(((:application eshell)
-	  eshell-connection-default-profile)
-	 ((:application tramp :machine "localhost")
-	  tramp-connection-local-darwin-ps-profile)
-	 ((:application tramp :machine "starlight.lan")
-	  tramp-connection-local-darwin-ps-profile)
-	 ((:application tramp)
-	  tramp-connection-local-default-system-profile tramp-connection-local-default-shell-profile)))
- '(connection-local-profile-alist
-   '((eshell-connection-default-profile
-	  (eshell-path-env-list))
-	 (tramp-connection-local-darwin-ps-profile
-	  (tramp-process-attributes-ps-args "-acxww" "-o" "pid,uid,user,gid,comm=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ" "-o" "state=abcde" "-o" "ppid,pgid,sess,tty,tpgid,minflt,majflt,time,pri,nice,vsz,rss,etime,pcpu,pmem,args")
-	  (tramp-process-attributes-ps-format
-	   (pid . number)
-	   (euid . number)
-	   (user . string)
-	   (egid . number)
-	   (comm . 52)
-	   (state . 5)
-	   (ppid . number)
-	   (pgrp . number)
-	   (sess . number)
-	   (ttname . string)
-	   (tpgid . number)
-	   (minflt . number)
-	   (majflt . number)
-	   (time . tramp-ps-time)
-	   (pri . number)
-	   (nice . number)
-	   (vsize . number)
-	   (rss . number)
-	   (etime . tramp-ps-time)
-	   (pcpu . number)
-	   (pmem . number)
-	   (args)))
-	 (tramp-connection-local-busybox-ps-profile
-	  (tramp-process-attributes-ps-args "-o" "pid,user,group,comm=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ" "-o" "stat=abcde" "-o" "ppid,pgid,tty,time,nice,etime,args")
-	  (tramp-process-attributes-ps-format
-	   (pid . number)
-	   (user . string)
-	   (group . string)
-	   (comm . 52)
-	   (state . 5)
-	   (ppid . number)
-	   (pgrp . number)
-	   (ttname . string)
-	   (time . tramp-ps-time)
-	   (nice . number)
-	   (etime . tramp-ps-time)
-	   (args)))
-	 (tramp-connection-local-bsd-ps-profile
-	  (tramp-process-attributes-ps-args "-acxww" "-o" "pid,euid,user,egid,egroup,comm=abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ" "-o" "state,ppid,pgid,sid,tty,tpgid,minflt,majflt,time,pri,nice,vsz,rss,etimes,pcpu,pmem,args")
-	  (tramp-process-attributes-ps-format
-	   (pid . number)
-	   (euid . number)
-	   (user . string)
-	   (egid . number)
-	   (group . string)
-	   (comm . 52)
-	   (state . string)
-	   (ppid . number)
-	   (pgrp . number)
-	   (sess . number)
-	   (ttname . string)
-	   (tpgid . number)
-	   (minflt . number)
-	   (majflt . number)
-	   (time . tramp-ps-time)
-	   (pri . number)
-	   (nice . number)
-	   (vsize . number)
-	   (rss . number)
-	   (etime . number)
-	   (pcpu . number)
-	   (pmem . number)
-	   (args)))
-	 (tramp-connection-local-default-shell-profile
-	  (shell-file-name . "/bin/sh")
-	  (shell-command-switch . "-c"))
-	 (tramp-connection-local-default-system-profile
-	  (path-separator . ":")
-	  (null-device . "/dev/null"))))
  '(custom-safe-themes
    '("88f7ee5594021c60a4a6a1c275614103de8c1435d6d08cc58882f920e0cec65e" "000ae191922c662e7f89eae84932415f9d7f5c3045b167b3375c2ad9b62a0c78" "4f7b78f1db71645999a8d632fe1d5cf863750a75b2153d429e59051827e439f2" "f40d0dc5fd64fef08959e2f5a35050baeb98faef572c233b7dcc3f89f0feed69" "574167ab321bb3041545e414a466cb30c48ec41d4ec27593c58be78d837575cc" "02f57ef0a20b7f61adce51445b68b2a7e832648ce2e7efb19d217b6454c1b644" "0e83cec64ea5e9d63769fd8644936d367f624f83d7cd5310c949f74b8975d305" default))
  '(org-agenda-files nil)

--- a/install-fonts.sh
+++ b/install-fonts.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+font_src_dir="$(pwd)/fonts"
+
+find_command="find \"$font_src_dir\" \( -name '*.[o,t]tf' -or -name '*.pcf.gz' \) -type f -print0"
+
+if [[ `uname` == 'Darwin' ]]; then
+  # MacOS
+  target_dir="$HOME/Library/Fonts"
+else
+  # Linux
+  target_dir="$HOME/.local/share/fonts"
+  mkdir -p $target_dir
+fi
+
+echo -e "Run: $find_command | xargs -0 -I % cp \"%\" \"$target_dir/\"\n"
+
+# Copy all fonts to user fonts directory
+echo "Copying fonts..."
+# printing
+eval $find_command | xargs -0 -I %
+
+eval $find_command | xargs -0 -I % cp "%" "$target_dir/"
+
+# Reset font cache on Linux
+if command -v fc-cache @>/dev/null ; then
+    echo -e "\nResetting font cache, this may take a moment..."
+    fc-cache -f $target_dir
+fi
+
+echo -e "\nAll fonts have been installed to $target_dir"
+


### PR DESCRIPTION
Currently `discover.el` is clobbering common `consult` keymaps.
This PR removes those conflicts (by way of removing `discover.el`), as well as adds some quality of life improvements for initial startup.